### PR TITLE
update to add company id

### DIFF
--- a/app/controllers/api/v1/call_rail_data_controller.rb
+++ b/app/controllers/api/v1/call_rail_data_controller.rb
@@ -4,8 +4,16 @@ module Api
       def index
         if params[:company_id]
           Rails.logger.info "Fetching data for Company ID: #{params[:company_id]}"
-          service = CallRailService.new('53962143e3bd0ab2989770ecbe94a75c', params[:company_id])
-          response = service.fetch_calls
+          
+          # Use GgtCallRailService if the request is for GGT
+          if params[:company_id] == '176449112'
+            service = GgtCallRailService.new
+            response = service.fetch_calls
+          else
+            # Default to CallRailService for other companies
+            service = CallRailService.new('53962143e3bd0ab2989770ecbe94a75c', params[:company_id])
+            response = service.fetch_calls
+          end
 
           if response.success?
             Rails.logger.info "Successful response for Company ID #{params[:company_id]}"
@@ -43,7 +51,7 @@ module Api
 
             calls = CallRailData.where(company_id: params[:company_id])
           else
-            Rails.logger.error "Error response from CallRailService: #{response.message}"
+            Rails.logger.error "Error response from service: #{response.message}"
             calls = CallRailData.none
           end
         else

--- a/app/services/ggt_call_rail_service.rb
+++ b/app/services/ggt_call_rail_service.rb
@@ -1,0 +1,17 @@
+class GgtCallRailService
+  include HTTParty
+  base_uri 'https://api.callrail.com/v3/a'
+
+
+  def fetch_calls
+    url = "/377749628/calls.json?company_id=176449112"
+    options = { headers: { "Authorization" => "Token token=9ef659a004baf7e1897723f4d3c3a115" } }
+    
+    Rails.logger.info "Requesting GGT URL: #{self.class.base_uri + url} with options: #{options}"
+    response = self.class.get(url, options)
+    Rails.logger.info "GGT Response code: #{response.code}"
+    Rails.logger.info "GGT Response body: #{response.body}"
+
+    response
+  end
+end

--- a/lib/tasks/fetch_call_data.rake
+++ b/lib/tasks/fetch_call_data.rake
@@ -5,7 +5,7 @@ namespace :call_rail do
       Rails.logger.info "Processing company: #{company_name} with ID: #{company_id}"
 
       # Initialize services for primary and secondary fetches
-      primary_service = CallRailService.new(ENV['CALLRAIL_API_KEY_PRIMARY'], ENV['CALLRAIL_COMPANY_ID_PRIMARY'], company_id)
+      primary_service = company_id == '176449112' ? GgtCallRailService.new : CallRailService.new(ENV['CALLRAIL_API_KEY_PRIMARY'], ENV['CALLRAIL_COMPANY_ID_PRIMARY'], company_id)
       secondary_service = CallRailService.new(ENV['CALLRAIL_API_KEY_SECONDARY'], ENV['CALLRAIL_COMPANY_ID_SECONDARY'], company_id)
 
       # Fetch data from primary and secondary sources
@@ -23,6 +23,7 @@ namespace :call_rail do
           Rails.logger.info "Processing call with ID: #{call['id']} for Company ID: #{company_id}"
           call_rail_data = CallRailData.find_or_initialize_by(call_id: call["id"])
 
+          # Check if the call is from GGT service and set the company ID specifically
           call_rail_data.assign_attributes(
             answered: call["answered"],
             business_phone_number: call["business_phone_number"],
@@ -39,7 +40,7 @@ namespace :call_rail do
             start_time: call["start_time"],
             tracking_phone_number: call["tracking_phone_number"],
             voicemail: call["voicemail"],
-            company_id: company_id,
+            company_id: company_id == '176449112' ? '176449112' : company_id, # Ensure GGT ID is set
           )
 
           if call_rail_data.save


### PR DESCRIPTION
**Pull Request: Update CallRail Service for GGT Company ID**

- **Updated CallRailDataController**:
  - Adjusted to use `GgtCallRailService` when `company_id` is `176449112`.
  - Updated logging and error messages for clearer output.

- **Added GgtCallRailService**:
  - New service for GGT-specific API calls with hardcoded company ID (`176449112`).

- **Updated Rake Task (fetch_call_data.rake)**:
  - Configured to initialize `GgtCallRailService` when processing GGT data.
  - Ensured `company_id` is explicitly set for GGT calls. 

